### PR TITLE
Update Picasso version to avoid conflicts with other libraries

### DIFF
--- a/fcm-channel/build.gradle
+++ b/fcm-channel/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     api project(':core')
-    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     api 'com.github.ilhasoft:hover:82b1a4c18f'

--- a/fcm-channel/build.gradle
+++ b/fcm-channel/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     api 'com.github.ilhasoft:hover:82b1a4c18f'
-    api 'org.bitbucket.ilhasoft.support-core:media:0.9.0'
+    api 'org.bitbucket.ilhasoft.support-core:media:1.0.0'
 
     api 'com.google.firebase:firebase-core:17.0.1'
     api 'com.google.firebase:firebase-messaging:19.0.1'

--- a/fcm-channel/src/main/java/io/fcmchannel/sdk/chat/ChatMessageViewHolder.java
+++ b/fcm-channel/src/main/java/io/fcmchannel/sdk/chat/ChatMessageViewHolder.java
@@ -233,7 +233,7 @@ class ChatMessageViewHolder extends RecyclerView.ViewHolder {
         if (firstImageAttachment != null) {
             image.setVisibility(View.VISIBLE);
             setOnImageAttachmentClickListener(image, attachmentMedias);
-            Picasso.with(image.getContext())
+            Picasso.get()
                 .load(firstImageAttachment.getUrl())
                 .into(image);
         }


### PR DESCRIPTION
Public interface changed on https://github.com/square/picasso/commit/e7e919232fe2b15772a7fcd9e15ead2304c66fae
and it was conflicting with latest In-App-Messaging version.

https://github.com/firebase/firebase-android-sdk/blob/master/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle#L82

Dependency tree resolution for Picasso:
```
+--- org.bitbucket.ilhasoft.support-core:media:0.9.0
|    \--- com.squareup.picasso:picasso:2.5.2 -> 2.71828 (*)
\--- com.squareup.picasso:picasso:2.5.2 -> 2.71828 (*)
```